### PR TITLE
Add Escape key support for project image viewer

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Briefcase, Code, Link as LinkIcon, X } from 'lucide-react'
 import SocialPill from './SocialPill'
 import {
@@ -67,6 +67,20 @@ export default function Projects() {
         document.body.style.overflow = 'auto';
         setSelectedImage(null)
     }
+
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') {
+                closeImage();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, []);
 
     return (
         <>


### PR DESCRIPTION
## Summary
- add `useEffect` to handle `Escape` key
- register a keydown listener when Projects mounts
- remove the listener on unmount

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68578e6da1b48330aee30adca6552325