### PR TITLE
Add Projects overlay keyboard dismissal test

### DIFF
--- a/src/components/Projects.test.jsx
+++ b/src/components/Projects.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Projects from './Projects'
+
+// Simple smoke test for closing overlay with Escape
+it('closes overlay with Escape key press', async () => {
+  render(<Projects />)
+  const screenshot = screen.getAllByAltText(/Captura de pantalla/)[0]
+  await userEvent.click(screenshot)
+
+  // verify overlay visible and scrolling disabled
+  expect(screen.getByAltText('Vista ampliada del proyecto')).toBeInTheDocument()
+  expect(document.body.style.overflow).toBe('hidden')
+
+  await userEvent.keyboard('{Escape}')
+
+  expect(screen.queryByAltText('Vista ampliada del proyecto')).not.toBeInTheDocument()
+  expect(document.body.style.overflow).toBe('auto')
+})


### PR DESCRIPTION
## Summary
- add React Testing Library test for Projects overlay dismissal with Escape

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68578f7a87408330b26dc92dff46ca11